### PR TITLE
Remove log rotation configs

### DIFF
--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -23,6 +23,8 @@ rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;\
+rm -f /etc/logrotate.d/glusterfs
+rm -f /etc/logrotate.d/glusterfs-georep
 yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs-libs-3.12.6-1.el7 glusterfs-fuse-3.12.6-1.el7 glusterfs-rdma-3.12.6-1.el7 glusterfs-geo-replication-3.12.6-1.el7 glusterfs-3.12.6-1.el7 glusterfs-client-xlators-3.12.6-1.el7 glusterfs-api-3.12.6-1.el7 glusterfs-cli-3.12.6-1.el7 python2-gluster-3.12.6-1.el7 glusterfs-server-3.12.6-1.el7  ; yum clean all; \
 sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers; \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config; \

--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -23,9 +23,9 @@ rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;\
+yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs-libs-3.12.6-1.el7 glusterfs-fuse-3.12.6-1.el7 glusterfs-rdma-3.12.6-1.el7 glusterfs-geo-replication-3.12.6-1.el7 glusterfs-3.12.6-1.el7 glusterfs-client-xlators-3.12.6-1.el7 glusterfs-api-3.12.6-1.el7 glusterfs-cli-3.12.6-1.el7 python2-gluster-3.12.6-1.el7 glusterfs-server-3.12.6-1.el7  ; yum clean all; \
 rm -f /etc/logrotate.d/glusterfs
 rm -f /etc/logrotate.d/glusterfs-georep
-yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs-libs-3.12.6-1.el7 glusterfs-fuse-3.12.6-1.el7 glusterfs-rdma-3.12.6-1.el7 glusterfs-geo-replication-3.12.6-1.el7 glusterfs-3.12.6-1.el7 glusterfs-client-xlators-3.12.6-1.el7 glusterfs-api-3.12.6-1.el7 glusterfs-cli-3.12.6-1.el7 python2-gluster-3.12.6-1.el7 glusterfs-server-3.12.6-1.el7  ; yum clean all; \
 sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers; \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config; \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service; \

--- a/CentOS/Dockerfile
+++ b/CentOS/Dockerfile
@@ -24,8 +24,8 @@ rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;\
 yum --setopt=tsflags=nodocs -y install nfs-utils attr iputils iproute openssh-server openssh-clients ntp rsync tar cronie sudo xfsprogs glusterfs-libs-3.12.6-1.el7 glusterfs-fuse-3.12.6-1.el7 glusterfs-rdma-3.12.6-1.el7 glusterfs-geo-replication-3.12.6-1.el7 glusterfs-3.12.6-1.el7 glusterfs-client-xlators-3.12.6-1.el7 glusterfs-api-3.12.6-1.el7 glusterfs-cli-3.12.6-1.el7 python2-gluster-3.12.6-1.el7 glusterfs-server-3.12.6-1.el7  ; yum clean all; \
-rm -f /etc/logrotate.d/glusterfs
-rm -f /etc/logrotate.d/glusterfs-georep
+rm -f /etc/logrotate.d/glusterfs; \
+rm -f /etc/logrotate.d/glusterfs-georep; \
 sed -i '/Defaults    requiretty/c\#Defaults    requiretty' /etc/sudoers; \
 sed -i '/Port 22/c\Port 2222' /etc/ssh/sshd_config; \
 sed -i 's/Requires\=rpcbind\.service//g' /usr/lib/systemd/system/glusterd.service; \


### PR DESCRIPTION
`/var/log/glusterfs` is common for host and container so it should be rotated only in one place, and host looks like a better option